### PR TITLE
Allow driver adding update + Customer hotfix

### DIFF
--- a/src/main/java/com/inthebytes/orderservice/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/inthebytes/orderservice/controller/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.inthebytes.orderservice.controller;
 
 import java.sql.SQLIntegrityConstraintViolationException;
 
+import javax.persistence.EntityNotFoundException;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +12,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.inthebytes.orderservice.exception.EntityNotExistsException;
 import com.inthebytes.orderservice.exception.InvalidSubmissionException;
 import com.inthebytes.orderservice.exception.NotAuthorizedException;
@@ -18,9 +19,9 @@ import com.inthebytes.orderservice.exception.NotAuthorizedException;
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	
-	@ExceptionHandler(value = EntityNotExistsException.class)
+	@ExceptionHandler(value = {EntityNotExistsException.class, EntityNotFoundException.class})
 	protected ResponseEntity<Object> handleNotFound(
-			EntityNotExistsException exc, WebRequest request) {
+			EntityNotFoundException exc, WebRequest request) {
 	
 		String body = "An ID provided in the request body or endpoint does not exist";
         return handleExceptionInternal(exc,	body, 

--- a/src/main/java/com/inthebytes/orderservice/dao/DriverDao.java
+++ b/src/main/java/com/inthebytes/orderservice/dao/DriverDao.java
@@ -1,0 +1,13 @@
+package com.inthebytes.orderservice.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.inthebytes.orderservice.entity.Driver;
+import com.inthebytes.orderservice.entity.User;
+
+@Repository
+public interface DriverDao extends JpaRepository<Driver, String> {
+	
+	Driver findByDriver(User driver);
+}

--- a/src/main/java/com/inthebytes/orderservice/dto/OrderSubmissionDto.java
+++ b/src/main/java/com/inthebytes/orderservice/dto/OrderSubmissionDto.java
@@ -35,6 +35,8 @@ public class OrderSubmissionDto {
 			groups = {AdminSubmissionCheck.class, UserSubmissionCheck.class})
 	private List<ItemDto> items;
 	
+	private String driverId;
+	
 	private Integer status;
 	
 	@Temporal(TemporalType.TIMESTAMP)
@@ -94,6 +96,14 @@ public class OrderSubmissionDto {
 
 	public void setStatus(Integer status) {
 		this.status = status;
+	}
+
+	public String getDriverId() {
+		return driverId;
+	}
+
+	public void setDriverId(String driverId) {
+		this.driverId = driverId;
 	}
 
 	public Timestamp getWindowStart() {

--- a/src/main/java/com/inthebytes/orderservice/entity/Delivery.java
+++ b/src/main/java/com/inthebytes/orderservice/entity/Delivery.java
@@ -1,6 +1,7 @@
 package com.inthebytes.orderservice.entity;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,6 +38,9 @@ public class Delivery implements Serializable {
 	@ManyToOne
 	@JoinColumn(name = "driver_id")
 	private Driver driver;
+	
+	@Column(name = "start_time")
+	private Timestamp startTime;
 
 	public String getId() {
 		return id;
@@ -60,6 +64,14 @@ public class Delivery implements Serializable {
 
 	public void setDriver(Driver driver) {
 		this.driver = driver;
+	}
+
+	public Timestamp getStartTime() {
+		return startTime;
+	}
+
+	public void setStartTime(Timestamp startTime) {
+		this.startTime = startTime;
 	}
 
 	public static long getSerialversionuid() {

--- a/src/main/java/com/inthebytes/orderservice/entity/Order.java
+++ b/src/main/java/com/inthebytes/orderservice/entity/Order.java
@@ -56,7 +56,7 @@ public class Order implements Serializable {
 	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
 	private List<OrderFood> foods;
 	
-	@OneToOne(mappedBy = "order", optional = true)
+	@OneToOne(mappedBy = "order", optional = true, cascade = CascadeType.PERSIST)
 	private Delivery delivery;
 
 	public String getId() {

--- a/src/main/java/com/inthebytes/orderservice/exception/EntityNotExistsException.java
+++ b/src/main/java/com/inthebytes/orderservice/exception/EntityNotExistsException.java
@@ -1,6 +1,8 @@
 package com.inthebytes.orderservice.exception;
 
-public class EntityNotExistsException extends RuntimeException {
+import javax.persistence.EntityNotFoundException;
+
+public class EntityNotExistsException extends EntityNotFoundException {
 
 	private static final long serialVersionUID = 8594434715685045731L;
 
@@ -8,23 +10,9 @@ public class EntityNotExistsException extends RuntimeException {
 		super();
 	}
 
-	public EntityNotExistsException(String message, Throwable cause, boolean enableSuppression,
-			boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
-
-	public EntityNotExistsException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
 	public EntityNotExistsException(String message) {
 		super(message);
+		// TODO Auto-generated constructor stub
 	}
-
-	public EntityNotExistsException(Throwable cause) {
-		super(cause);
-	}
-	
-	
 	
 }

--- a/src/main/java/com/inthebytes/orderservice/service/crud/CreateOrderService.java
+++ b/src/main/java/com/inthebytes/orderservice/service/crud/CreateOrderService.java
@@ -73,7 +73,7 @@ public class CreateOrderService {
 		switch (role) {
 		case "admin":
 			return adminCreate(order, data);
-		case "username":
+		case "customer":
 			return customerCreate(order, data, username);
 		default:
 			throw new NotAuthorizedException("Account not authorized to create orders");


### PR DESCRIPTION
Customer Hotfix: there was a bug in permissions for allowing customers to create orders for themselves. That bug has been fixed
Exception Handling: There was an uncovered Exception that should have been 404 - added to Exception Handler

Adding Drivers: Gave Admins the ability to add a driver to an order via PUT request (mainly for postman simulations for testing order tracking) - completely optional - skips implementation if order already has a driver or DriverID is not included on the request body